### PR TITLE
Type matching fixed for JaxbIntrospector

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
@@ -1076,7 +1076,7 @@ public class JaxbAnnotationIntrospector
 
     private boolean adapterTypeMatches(XmlAdapter<?,?> adapter, Class<?> targetType)
     {
-        return targetType.isAssignableFrom(findAdapterBoundType(adapter));
+        return findAdapterBoundType(adapter).isAssignableFrom(targetType);
     }
 
     private Class<?> findAdapterBoundType(XmlAdapter<?,?> adapter)


### PR DESCRIPTION
Hi, it was incorrect check of assignable type for XmlAdapter. Has impact on using @XmlJavaTypeAdapter annotation
