### PR TITLE
fix deserialization of Collection with @XmlJavaTypeAdapter on method

### DIFF
--- a/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
+++ b/src/main/java/com/fasterxml/jackson/module/jaxb/JaxbAnnotationIntrospector.java
@@ -1045,7 +1045,7 @@ public class JaxbAnnotationIntrospector
         // conversely, here we only apply this to container types:
         Class<?> deserType = _rawDeserializationType(a);
         if (isContainerType(deserType)) {
-            XmlAdapter<?,?> adapter = _findContentAdapter(a, true);
+            XmlAdapter<?,?> adapter = _findContentAdapter(a, false);
             if (adapter != null) {
                 return _converter(adapter, false);
             }
@@ -1302,7 +1302,7 @@ public class JaxbAnnotationIntrospector
         
         if (adaptedType == XmlJavaTypeAdapter.DEFAULT.class) {
             JavaType[] params = _typeFactory.findTypeParameters(adapterInfo.value(), XmlAdapter.class);
-            adaptedType = params[forSerialization ? 1 : 0].getRawClass();
+            adaptedType = params[1].getRawClass();
         }
         if (adaptedType.isAssignableFrom(typeNeeded)) {
             @SuppressWarnings("rawtypes")

--- a/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdaptersForContainers.java
+++ b/src/test/java/com/fasterxml/jackson/module/jaxb/adapters/TestAdaptersForContainers.java
@@ -86,6 +86,25 @@ public class TestAdaptersForContainers extends BaseJaxbTest
             values.add(new Date(l));
         }
     }
+
+    static class WrapperWithGetterAndSetter {
+        private List<Date> values;
+
+        public WrapperWithGetterAndSetter() { }
+        public WrapperWithGetterAndSetter(long l) {
+            values = new ArrayList<Date>();
+            values.add(new Date(l));
+        }
+
+        @XmlJavaTypeAdapter(SillyAdapter.class)
+        public List<Date> getValues() {
+            return values;
+        }
+
+        public void setValues(List<Date> values) {
+            this.values = values;
+        }
+    }
     
     /*
     /**********************************************************
@@ -102,6 +121,22 @@ public class TestAdaptersForContainers extends BaseJaxbTest
     public void testSimpleAdapterDeserialization() throws Exception
     {
         Wrapper w = getJaxbMapper().readValue("{\"values\":[\"abc\"]}", Wrapper.class);
+        assertNotNull(w);
+        assertNotNull(w.values);
+        assertEquals(1, w.values.size());
+        assertEquals(29L, w.values.get(0).getTime());
+    }
+
+    public void testAdapterOnGetterSerialization() throws Exception
+    {
+        WrapperWithGetterAndSetter w = new WrapperWithGetterAndSetter(123L);
+        assertEquals("{\"values\":[\"XXX\"]}", getJaxbMapper().writeValueAsString(w));
+    }
+
+    public void testAdapterOnGetterDeserialization() throws Exception
+    {
+        WrapperWithGetterAndSetter w = getJaxbMapper().readValue("{\"values\":[\"abc\"]}",
+                WrapperWithGetterAndSetter.class);
         assertNotNull(w);
         assertNotNull(w.values);
         assertEquals(1, w.values.size());


### PR DESCRIPTION
This fixes a bug (regression, I think?) where an @XmlJavaTypeAdapter applied to a method (getter or setter) for a collection type is applied only during serialization but not deserialization. A unit test is included demonstrating the issue and the fix.

The fix involves two small parts.

First, it changes findDeserializationContentConverter to call _findContentAdapter with forSerialization = false. This causes _findContentAdapter to look at the parameter of the setter as the expected type of the adapter, rather than incorrectly using the return value which is often or always void.

Second, it also changes checkAdapter to always check the second adapter type parameter, which is the bound type (the type used in the java representation). Using the value type, as the previous behavior did based on forSerialization, does not seem correct: the java
code, both for serialization and deserialization, for getter and for setter and field, is always using the
bound type. This wasn't an issue before as all the call sites (ignoring potential external subclasses) used forSerialization = true.

I did not dig into why the non-collection annotated method deserialization paths still work when calling _findContentAdapter with forSerialization = true, but the existing tests show they work.

Thanks for looking and all your work on jackson,
Andy
